### PR TITLE
Change input device by path to by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Options:
 
 Note: default soundpack path is `./`(current directory)
 
-wayvibes <soundpack_path> -v <volume(0.0-10.0)> --device-name <name>
+wayvibes <soundpack_path> -v <volume(0.0-10.0)>
 ```
 
 > [!NOTE]
@@ -126,7 +126,7 @@ wayvibes <soundpack_path> -v <volume(0.0-10.0)> --device-name <name>
 **Example:**
 
 ```bash
-wayvibes ~/wayvibes/soundpacks/akko_lavender_purples/ -v 3 --device-name 'ITE Tech. Inc. ITE Device Keyboard'
+wayvibes ~/wayvibes/soundpacks/akko_lavender_purples/ -v 3
 wayvibes ~/wayvibes/soundpacks/nk-cream/ -v 5 --background
 ```
 

--- a/README.md
+++ b/README.md
@@ -109,14 +109,15 @@ sudo usermod -a -G input <your_username>
 ```
 Usage: wayvibes [options] [soundpack_path]
 Options:
-  --device          Select input device
-  -v <volume>       Set volume (0.0-10.0) (default: 1.0)
-  --background, -bg Run in background (detached from terminal)
-  --help, -h       Show this help message;
+  --device              Select input device
+  --device-name <name>  Use input device by name
+  -v <volume>           Set volume (0.0-10.0) (default: 1.0)
+  --background, -bg     Run in background (detached from terminal)
+  --help, -h            Show this help message;
 
 Note: default soundpack path is `./`(current directory)
 
-wayvibes <soundpack_path> -v <volume(0.0-10.0)>
+wayvibes <soundpack_path> -v <volume(0.0-10.0)> --device-name <name>
 ```
 
 > [!NOTE]
@@ -125,7 +126,7 @@ wayvibes <soundpack_path> -v <volume(0.0-10.0)>
 **Example:**
 
 ```bash
-wayvibes ~/wayvibes/soundpacks/akko_lavender_purples/ -v 3
+wayvibes ~/wayvibes/soundpacks/akko_lavender_purples/ -v 3 --device-name 'ITE Tech. Inc. ITE Device Keyboard'
 wayvibes ~/wayvibes/soundpacks/nk-cream/ -v 5 --background
 ```
 
@@ -138,7 +139,7 @@ wayvibes ~/wayvibes/soundpacks/nk-cream/ -v 5 --background
 
 Upon the first run, Wayvibes will prompt you to select your keyboard device if there are multiple available. This selection will be stored in:
 
-`$XDG_CONFIG_HOME/wayvibes/input_device_path`
+`$XDG_CONFIG_HOME/wayvibes/input_device_name`
 
 Typically, the input device will be something like `AT Translated Set 2 keyboard` or `USB Keyboard`. If you use a key remapper like `keyd`, select its virtual device (e.g., `keyd virtual keyboard`).
 
@@ -152,12 +153,6 @@ If you use NixOS, you have to restart the service after changing the device.
 ```bash
 systemctl --user restart wayvibes.service
 ```
-
-> [!NOTE]
->
-> - **Device Path Persistence**: The program automatically uses stable `/dev/input/by-id/` paths when available.
-> - If the selected device doesn't have a by-id symlink, it will fallback to non-persistent paths, which **can change** when you reboot after plugging/unplugging devices
-> - Use `--device` to select the device again in such cases.
 
 > [!WARNING]
 > **Do not run the program with sudo/root privileges as it will monopolize the audio device until reboot.**

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -107,42 +107,59 @@ std::string findKeyboardDevices() {
   return selectedDevice;
 }
 
-std::string resolveToByIdPath(const std::string &eventDevice) {
-  namespace fs = std::filesystem;
-  std::string byIdDir = "/dev/input/by-id/";
-
-  try {
-    if (!fs::exists(byIdDir)) {
-      return ""; // No by-id directory, fallback to event path
-    }
-
-    std::string targetPath = fs::canonical(deviceDir + eventDevice);
-
-    for (const auto &entry : fs::directory_iterator(byIdDir)) {
-      if (fs::is_symlink(entry)) {
-        std::string linkTarget = fs::canonical(entry);
-
-        if (linkTarget == targetPath) {
-          return entry.path().string();
-        }
-      }
-    }
-  } catch (const std::exception &e) {
-    std::cerr << RED << "Error resolving symlink: " << e.what() << RESET << std::endl;
+std::string getDevicePathByName(const std::string &name) {
+  DIR *dir = opendir(deviceDir);
+  if (!dir) {
+    std::cerr << RED << "Failed to open /dev/input directory" << RESET << std::endl;
+    return "";
   }
 
-  return ""; // No matching symlink found
+  struct dirent *entry;
+  std::string foundPath = "";
+
+  while ((entry = readdir(dir)) != NULL) {
+    if (strncmp(entry->d_name, "event", 5) == 0) {
+      std::string devicePath = std::string(deviceDir) + entry->d_name;
+      struct libevdev *dev = nullptr;
+      int fd = open(devicePath.c_str(), O_RDONLY);
+      if (fd < 0) continue;
+
+      int rc = libevdev_new_from_fd(fd, &dev);
+      if (rc < 0) {
+        close(fd);
+        continue;
+      }
+
+      if (libevdev_has_event_code(dev, EV_KEY, KEY_A)) {
+        if (name == libevdev_get_name(dev)) {
+          foundPath = devicePath;
+          libevdev_free(dev);
+          close(fd);
+          break;
+        }
+      }
+
+      libevdev_free(dev);
+      close(fd);
+    }
+  }
+
+  closedir(dir);
+  return foundPath;
 }
 
 std::string getInputDevicePath(std::string &configDir) {
-  std::string inputFilePath = configDir + "/input_device_path";
+  std::string inputFilePath = configDir + "/input_device_name";
   std::ifstream inputFile(inputFilePath);
 
   if (inputFile.is_open()) {
-    std::string devicePath;
-    std::getline(inputFile, devicePath);
+    std::string deviceName;
+    std::getline(inputFile, deviceName);
     inputFile.close();
-    return devicePath;
+
+    if (!deviceName.empty()) {
+      return getDevicePathByName(deviceName);
+    }
   }
 
   return "";
@@ -151,23 +168,28 @@ std::string getInputDevicePath(std::string &configDir) {
 void saveInputDevice(std::string &configDir) {
   std::string selectedDevice = findKeyboardDevices();
   if (!selectedDevice.empty()) {
-    std::string byIdPath = resolveToByIdPath(selectedDevice);
-    std::string deviceToSave;
+    std::string devicePath = std::string(deviceDir) + selectedDevice;
+    int fd = open(devicePath.c_str(), O_RDONLY);
+    std::string deviceName;
 
-    if (!byIdPath.empty()) {
-      std::cout << GREEN << "\nUsing by-id path..." << RESET << std::endl;
-      deviceToSave = byIdPath;
-    } else {
-      std::cout << YELLOW << BOLD
-                << "\nNo by-id symlink found, using non-persistent event path..." << RESET
-                << std::endl;
-      deviceToSave = deviceDir + selectedDevice;
+    if (fd >= 0) {
+      struct libevdev *dev = nullptr;
+      if (libevdev_new_from_fd(fd, &dev) >= 0) {
+        deviceName = libevdev_get_name(dev);
+        libevdev_free(dev);
+      }
+      close(fd);
     }
 
-    std::ofstream outputFile(configDir + "/input_device_path");
-    outputFile << deviceToSave;
+    if (deviceName.empty()) {
+      std::cerr << RED << "Could not determine device name. Exiting." << RESET << std::endl;
+      exit(1);
+    }
+
+    std::ofstream outputFile(configDir + "/input_device_name");
+    outputFile << deviceName;
     outputFile.close();
-    std::cout << GREEN << "Device path saved: " << deviceToSave << RESET << std::endl;
+    std::cout << GREEN << "Device name saved: " << deviceName << RESET << std::endl;
   } else {
     std::cerr << RED << "No device selected. Exiting." << RESET << std::endl;
     exit(1);

--- a/src/device.h
+++ b/src/device.h
@@ -7,6 +7,9 @@
 // find available keyboard devices
 std::string findKeyboardDevices();
 
+// get the path of a device by its exact name
+std::string getDevicePathByName(const std::string &name);
+
 void runMainLoop(const std::string &devicePath,
                  const std::unordered_map<int, std::string> &keySoundMap, float volume,
                  const std::string &soundpackPath);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,8 +17,7 @@ void printHelp() {
             << "  --background, -bg     Run in background (detached from terminal)\n"
             << "  --help, -h            Show this help message\n"
             << "Note: default soundpack path is './' (current directory)\n"
-            << "Example: wayvibes ~/wayvibes/akko_lavender_purples/ -v 3 --device-name "
-               "'ITE Tech. Inc. ITE Device Keyboard'"
+            << "Example: wayvibes ~/wayvibes/akko_lavender_purples/ -v 3"
             << std::endl;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,18 +11,22 @@
 void printHelp() {
   std::cout << "Usage: wayvibes [options] [soundpack_path]\n"
             << "Options:\n"
-            << "  --device          Select input device\n"
-            << "  -v <volume>       Set volume (0.0-10.0) (default: 1.0)\n"
-            << "  --background, -bg Run in background (detached from terminal)\n"
-            << "  --help, -h       Show this help message\n"
-            << "Note: default soundpack path is './' (current directory) "
-            << "Example: wayvibes ~/wayvibes/akko_lavender_purples/ -v 3" << std::endl;
+            << "  --device              Select input device\n"
+            << "  --device-name <name>  Find and use input device by exact name\n"
+            << "  -v <volume>           Set volume (0.0-10.0) (default: 1.0)\n"
+            << "  --background, -bg     Run in background (detached from terminal)\n"
+            << "  --help, -h            Show this help message\n"
+            << "Note: default soundpack path is './' (current directory)\n"
+            << "Example: wayvibes ~/wayvibes/akko_lavender_purples/ -v 3 --device-name "
+               "'ITE Tech. Inc. ITE Device Keyboard'"
+            << std::endl;
 }
 
 int main(int argc, char *argv[]) {
   std::string soundpackPath = "./";
   float volume = 1.0f;
   std::string configDir;
+  std::string targetDeviceName = "";
   bool silent = false;
   const char *xdgConfigHome = std::getenv("XDG_CONFIG_HOME");
   configDir = (xdgConfigHome ? xdgConfigHome : std::string(getenv("HOME")) + "/.config") +
@@ -36,6 +40,9 @@ int main(int argc, char *argv[]) {
     if (std::string(argv[i]) == "--device") {
       saveInputDevice(configDir);
       return 0;
+    } else if ((std::string(argv[i]) == "--device-name") && (i + 1) < argc) {
+      targetDeviceName = argv[i + 1];
+      i++;
     } else if (std::string(argv[i]) == "-v" && (i + 1) < argc) {
       try {
         volume = std::stof(argv[i + 1]);
@@ -86,12 +93,24 @@ int main(int argc, char *argv[]) {
   std::unordered_map<int, std::string> keySoundMap =
       loadKeySoundMappings(soundpackPath + "/config.json");
 
-  std::string devicePath = getInputDevicePath(configDir);
+  std::string devicePath;
 
-  if (devicePath.empty()) {
-    if (!silent) std::cout << "No device found. Prompting user." << std::endl;
-    saveInputDevice(configDir);
+  if (!targetDeviceName.empty()) {
+    devicePath = getDevicePathByName(targetDeviceName);
+    if (devicePath.empty()) {
+      if (!silent)
+        std::cerr << "Device with name '" << targetDeviceName << "' not found."
+                  << std::endl;
+      return 1;
+    }
+  } else {
     devicePath = getInputDevicePath(configDir);
+
+    if (devicePath.empty()) {
+      if (!silent) std::cout << "No device found. Prompting user." << std::endl;
+      saveInputDevice(configDir);
+      devicePath = getInputDevicePath(configDir);
+    }
   }
 
   runMainLoop(devicePath, keySoundMap, volume, soundpackPath);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@ void printHelp() {
   std::cout << "Usage: wayvibes [options] [soundpack_path]\n"
             << "Options:\n"
             << "  --device              Select input device\n"
-            << "  --device-name <name>  Find and use input device by exact name\n"
+            << "  --device-name <name>  Use input device by exact name\n"
             << "  -v <volume>           Set volume (0.0-10.0) (default: 1.0)\n"
             << "  --background, -bg     Run in background (detached from terminal)\n"
             << "  --help, -h            Show this help message\n"


### PR DESCRIPTION
I use NixOS and NixOS needs to rebuild its system whenever I change its config. The problem is sometimes after rebuild, the keyboard input device path changes and I have to select the correct device again. To make it persistent, I made it save and read the device name instead of device path in `~/.config/wayvibes/input_device_name` file. Wayvibes will read the name and then get the path from that name. I also added an argument `--device-name <name>` to choose the device from the command line.